### PR TITLE
6 create settings menu

### DIFF
--- a/Dungeon_Crawler/Game/Controllers/Game_Manager/__init__.py
+++ b/Dungeon_Crawler/Game/Controllers/Game_Manager/__init__.py
@@ -99,6 +99,8 @@ class GameManager():
     @classmethod
     def begin_game_loop(cls, event):
         while True:
+            # if UIManager.main_menu.is_enabled():
+            #     UIManager.main_menu.start_main_loop()
             pygame.event.pump()
             if cls.is_new_game:
                 cls.begin_intro()

--- a/Dungeon_Crawler/Game/Controllers/Game_Manager/__init__.py
+++ b/Dungeon_Crawler/Game/Controllers/Game_Manager/__init__.py
@@ -48,6 +48,7 @@ class GameManager():
         EventController.add_listener(event_type=EventTypes.ON_MUSIC_TRACK_PLAY, handler_functions=[MusicController.play_music_by_track])
         EventController.add_listener(event_type=EventTypes.ON_SFX_PLAY, handler_functions=[MusicController.play_sfx])
         EventController.add_listener(event_type=EventTypes.ON_SFX_STOP, handler_functions=[MusicController.stop_sfx])
+        EventController.add_listener(event_type=EventTypes.ON_VOLUME_CHANGE, handler_functions=[MusicController.change_volume])
         EventController.add_listener(event_type=EventTypes.ON_INVENTORY_DISPLAY, handler_functions=[PlayerController.display_inventory])
         EventController.add_listener(event_type=EventTypes.ON_SHOW_ITEM_ACTIONS, handler_functions=[MessagesController.show_item_actions])
         EventController.add_listener(event_type=EventTypes.ON_ITEM_DROP, handler_functions=[PlayerController.drop_from_inventory])

--- a/Dungeon_Crawler/Game/Controllers/Music_Controller/__init__.py
+++ b/Dungeon_Crawler/Game/Controllers/Music_Controller/__init__.py
@@ -66,3 +66,9 @@ class MusicController(BaseController):
         
         mixer.Sound.stop(cls.active_sounds[event.sfx_name])
         cls.active_sounds.pop(event.sfx_name)
+
+    @classmethod
+    def change_volume(cls, event):
+        if event:
+            volume = event.volume_value
+            mixer.music.set_volume(volume*0.01)

--- a/Dungeon_Crawler/Game/Controllers/UI_Controller/__init__.py
+++ b/Dungeon_Crawler/Game/Controllers/UI_Controller/__init__.py
@@ -5,7 +5,7 @@ from time import sleep
 from Controllers.base_controller import BaseController
 from Controllers.Surfaces_Registry import SurfacesRegistry
 from Controllers.EventController import EventController
-from Controllers.game_events import OnDieEvent
+from Controllers.game_events import OnDieEvent, OnVolumeChangeEvent
 from Controllers.Player_Controller import PlayerStatusCharacteristic
 
 
@@ -188,7 +188,17 @@ class AudioMenu():
             width=cls.menu_width
         )
 
+        cls.volume_slider = cls.menu.add.range_slider(
+            "Volume", 50, (0, 100), 1, cls.change_volume
+        )
+
         cls.menu.add.button("Back", pygame_menu.events.BACK)
+
+    @classmethod
+    def change_volume(cls, volume):
+        evt = OnVolumeChangeEvent()
+        evt.volume_value = volume
+        EventController.broadcast_event(event_object=evt)
 
 class GameplayMenu():
     @classmethod

--- a/Dungeon_Crawler/Game/Controllers/UI_Controller/__init__.py
+++ b/Dungeon_Crawler/Game/Controllers/UI_Controller/__init__.py
@@ -1,5 +1,5 @@
 from enum import Enum
-import random
+import pygame_menu
 import pygame
 from time import sleep
 from Controllers.base_controller import BaseController
@@ -7,6 +7,7 @@ from Controllers.Surfaces_Registry import SurfacesRegistry
 from Controllers.EventController import EventController
 from Controllers.game_events import OnDieEvent
 from Controllers.Player_Controller import PlayerStatusCharacteristic
+
 
 WIDTH = 1280
 HEIGHT = 720
@@ -47,6 +48,7 @@ class UIManager(BaseController):
         cls.message_side_panel_surf = MessagesSidePanelSurface()
         cls.text_cursor = TextCursor()
         cls.description_cursor = DescriptionCursor()
+        cls.settings_menu = SettingsMenu()
         
         cls.font = pygame.font.SysFont("monospace", 18)
         cls.rect = cls.window.get_rect()
@@ -68,6 +70,16 @@ class UIManager(BaseController):
         # pygame.draw.rect(cls.background, FUCHSIA, cls.background_rect, 5)
 
         cls.post_update()
+
+    @classmethod
+    def display_settings(cls):
+        cls.settings_menu.menu.draw(cls.background)
+        cls.settings_menu.menu.update(pygame.event.get())
+        cls.post_update()
+    
+    @classmethod
+    def toggle_settings_menu(cls):
+        cls.settings_menu.menu.toggle()
 
     @classmethod
     def clear_input_field(cls):
@@ -128,6 +140,89 @@ class UIManager(BaseController):
         cls.all_sprites.update()
         cls.window.blit(cls.background, (0, 0))
         pygame.display.flip()
+
+class SettingsMenu():
+    @classmethod
+    def __init__(cls):
+        cls.theme = pygame_menu.themes.THEME_DARK
+        cls.menu_height = 400
+        cls.menu_width = 600
+        cls.title = "Settings"
+
+        cls.menu = pygame_menu.Menu(
+            enabled=False,
+            height=cls.menu_height,
+            onclose=pygame_menu.events.RESET,
+            theme=cls.theme,
+            title=cls.title,
+            width=cls.menu_width
+        )
+
+        cls.audio_menu = AudioMenu().menu
+        cls.gameplay_menu = GameplayMenu().menu
+        cls.video_menu = VideoMenu().menu
+
+        cls.menu.add.button("Return to Game", cls.close_menu)
+        cls.menu.add.button(cls.audio_menu.get_title(), cls.audio_menu)
+        cls.menu.add.button(cls.gameplay_menu.get_title(), cls.gameplay_menu)
+        cls.menu.add.button(cls.video_menu.get_title(), cls.video_menu)
+        cls.menu.add.button("Quit Game", exit)
+
+    @classmethod
+    def close_menu(cls):
+        cls.menu.close()
+        UIManager.post_update()
+
+class AudioMenu():
+    @classmethod
+    def __init__(cls):
+        cls.theme = pygame_menu.themes.THEME_DARK
+        cls.menu_height = SettingsMenu.menu_height
+        cls.menu_width = SettingsMenu.menu_width
+        cls.title = "Audio"
+
+        cls.menu = pygame_menu.Menu(
+            height=cls.menu_height, 
+            theme=cls.theme,
+            title=cls.title,
+            width=cls.menu_width
+        )
+
+        cls.menu.add.button("Back", pygame_menu.events.BACK)
+
+class GameplayMenu():
+    @classmethod
+    def __init__(cls):
+        cls.theme = pygame_menu.themes.THEME_DARK
+        cls.menu_height = SettingsMenu.menu_height
+        cls.menu_width = SettingsMenu.menu_width
+        cls.title = "Gameplay"
+
+        cls.menu = pygame_menu.Menu(
+            height=cls.menu_height, 
+            theme=cls.theme,
+            title=cls.title,
+            width=cls.menu_width
+        )
+
+        cls.menu.add.button("Back", pygame_menu.events.BACK)
+
+class VideoMenu():
+    @classmethod
+    def __init__(cls):
+        cls.theme = pygame_menu.themes.THEME_DARK
+        cls.menu_height = SettingsMenu.menu_height
+        cls.menu_width = SettingsMenu.menu_width
+        cls.title = "Video"
+
+        cls.menu = pygame_menu.Menu(
+            height=cls.menu_height, 
+            theme=cls.theme,
+            title=cls.title,
+            width=cls.menu_width
+        )
+
+        cls.menu.add.button("Back", pygame_menu.events.BACK)
 
 class PlayerInputSurface(pygame.sprite.Sprite):
     @classmethod
@@ -298,9 +393,19 @@ class TextInput():
                         TextCursor.placement_on_line -= TextCursor.text_width
                         UIManager.post_update()
 
+                    elif event.key == pygame.K_ESCAPE:
+                        UIManager.toggle_settings_menu()
+                        while True:
+                            if UIManager.settings_menu.menu.is_enabled():
+                                UIManager.display_settings()
+                            else:
+                                break
 
                     elif len(user_text) < MAX_LETTER_COUNT:
                         user_text += event.unicode
                         UIManager.render_letter_to_input(letter=event.unicode)
                         UIManager.post_update()
 
+            # if UIManager.settings_menu.menu.is_enabled():
+            #     UIManager.display_settings()
+                

--- a/Dungeon_Crawler/Game/Controllers/game_events.py
+++ b/Dungeon_Crawler/Game/Controllers/game_events.py
@@ -22,6 +22,7 @@ class EventTypes():
         cls.ON_MUSIC_TRACK_PLAY = OnMusicTrackPlayEvent().__class__.__name__
         cls.ON_SFX_PLAY = OnSfxPlayEvent().__class__.__name__
         cls.ON_SFX_STOP = OnSfxStopEvent().__class__.__name__
+        cls.ON_VOLUME_CHANGE = OnVolumeChangeEvent().__class__.__name__
         cls.ON_ITEM_DROP = OnItemDrop().__class__.__name__
         cls.ON_NEXT_EVENT_CHANGE = OnNextEventChange().__class__.__name__
         cls.ON_CURRENT_EVENT_CHANGE = OnCurrentEventChange().__class__.__name__
@@ -48,6 +49,7 @@ class EventTypes():
             cls.ON_MUSIC_TRACK_PLAY,
             cls.ON_SFX_PLAY,
             cls.ON_SFX_STOP,
+            cls.ON_VOLUME_CHANGE,
             cls.ON_ITEM_DROP,
             cls.ON_NEXT_EVENT_CHANGE,
             cls.ON_CURRENT_EVENT_CHANGE,
@@ -121,6 +123,10 @@ class OnSfxPlayEvent(GameEvent):
 class OnSfxStopEvent(GameEvent):
     def __init__(self) -> None:
         self.sfx_name = None
+
+class OnVolumeChangeEvent(GameEvent):
+    def __init__(self) -> None:
+        self.volume_value = None
 
 class OnInventoryDisplay(GameEvent):
     def __init__(self) -> None:

--- a/Dungeon_Crawler/game_settings_config.json
+++ b/Dungeon_Crawler/game_settings_config.json
@@ -1,5 +1,5 @@
 {
-    "play_audio": false,
+    "play_audio": true,
     "message_typewriter_speed": "VERY_FAST",
     "starting_room": "intro_chamber_0",
     "starting_event": ""

--- a/Dungeon_Crawler/requirements.txt
+++ b/Dungeon_Crawler/requirements.txt
@@ -1,2 +1,3 @@
 Events==0.4
 pygame==2.1.3.dev8
+pygame-menu==4.2.8


### PR DESCRIPTION
This PR accomplishes the following:
- Implements a Settings menu that can be called by using the ESC key when game is waiting for user input
- Implements multiple buttons in the Settings menu, e.g. Video, Audio, Gameplay.
- Implement multiple menus that are attached to the Settings menu for Audio, Video, Gameplay, etc.
- Implements Volume control in the Settings -> Audio menu

Here's some relevant docs for reviewers:
- [Pygame Menu starting docs](https://pygame-menu.readthedocs.io/en/4.2.8/index.html)
- [Range Slider Widget docs, used for Volume](https://pygame-menu.readthedocs.io/en/4.2.8/_source/add_widgets.html#add-a-range-slider)
- [Example code where someone used multiple menus](https://github.com/ppizarror/pygame-menu/blob/3d4088bb8b75a0ed421390d574e1f36a2df89aa9/pygame_menu/examples/timer_clock.py#L112)